### PR TITLE
Include "mix certdata" task into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [the documentation](https://hexdocs.pm/castore).
 
 ## Contributing
 
-If you want to locally update the CA certificate store file bundled with this library, run the `mix certfile` from the root of this library.
+If you want to locally update the CA certificate store file bundled with this library, run `mix certdata` from the root of this library.
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule CAStore.MixProject do
 
   defp package do
     [
-      files: ["lib/castore.ex", "priv", "mix.exs", "README.md"],
+      files: ["lib/castore.ex", "lib/mix/tasks/certdata.ex", "priv", "mix.exs", "README.md"],
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => @repo_url}
     ]


### PR DESCRIPTION
`mix certdata` is not included in published packages. README typo is corrected too.